### PR TITLE
Refresh drop-in dev container for modern WordPress development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG WORDPRESS_IMAGE=wordpress:php8.4-apache
+ARG WORDPRESS_IMAGE=docker.io/library/wordpress:php8.4-apache
 FROM ${WORDPRESS_IMAGE}
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,58 +1,51 @@
-#-------------------------------------------------------------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
-#-------------------------------------------------------------------------------------------------------------
+ARG WORDPRESS_IMAGE=wordpress:php8.4-apache
+FROM ${WORDPRESS_IMAGE}
 
-FROM wordpress
-
-# Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-
-# Enable WP_DEBUG in wp-config.php
 ENV WORDPRESS_DEBUG=1
 
-# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
-# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
-# will be updated to match your local UID/GID (when using the dockerFile property).
-# See https://aka.ms/vscode-remote/containers/non-root-user for details.
 ARG USERNAME=vscode
 ARG USER_UID=1000
-ARG USER_GID=$USER_UID
+ARG USER_GID=${USER_UID}
 
-# Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
-    #
-    # install git iproute2, procps, lsb-release (useful for CLI installs)
-    && apt-get -y install git iproute2 procps iproute2 lsb-release \
-    #
-    # Install xdebug
+    && apt-get install -y --no-install-recommends \
+        apt-utils \
+        ca-certificates \
+        curl \
+        dialog \
+        git \
+        lsb-release \
+        procps \
+        iproute2 \
+        sudo \
+        unzip \
+        less \
+        default-mysql-client \
     && yes | pecl install xdebug \
     && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.remote_autostart=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    #
-    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
-    && groupadd --gid $USER_GID $USERNAME \
-    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
-    # [Optional] Add sudo support for the non-root user
-    && apt-get install -y sudo \
-    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
-    && chmod 0440 /etc/sudoers.d/$USERNAME \
-    #
-    # # Clean up
+    && echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.client_host=127.0.0.1" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && { \
+        echo "upload_max_filesize=128M"; \
+        echo "post_max_size=128M"; \
+        echo "memory_limit=256M"; \
+        echo "max_execution_time=300"; \
+        echo "max_input_time=300"; \
+    } > /usr/local/etc/php/conf.d/uploads.ini \
+    && groupadd --gid ${USER_GID} ${USERNAME} \
+    && useradd -s /bin/bash --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME} \
+    && usermod -aG www-data ${USERNAME} \
+    && echo "${USERNAME} ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/${USERNAME} \
+    && chmod 0440 /etc/sudoers.d/${USERNAME} \
+    && curl -fsSL -o /tmp/composer-setup.php https://getcomposer.org/installer \
+    && php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer \
+    && rm -f /tmp/composer-setup.php \
+    && curl -fsSL -o /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
+    && chmod +x /usr/local/bin/wp \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-# Switch back to dialog for any ad-hoc use of apt-get
 ENV DEBIAN_FRONTEND=dialog
-
-# Install Composer
-RUN curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer
-
-# Add WP-CLI 
-RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
-    && php wp-cli.phar --info \
-    && chmod +x wp-cli.phar \
-    && mv wp-cli.phar /usr/local/bin/wp

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,31 +1,28 @@
 {
-	"name": "WordPress Plugin Boilerplate",
+	"name": "WordPress Development",
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "wordpress",
 	"workspaceFolder": "/workspace",
 	"shutdownAction": "stopCompose",
-	
-	// Use 'settings' to set *default* container specific settings.json values on container create. 
-	// You can edit these settings after create using File > Preferences > Settings > Remote.
-	"settings": { 
-		"terminal.integrated.shell.linux": "/bin/bash"
-	},
-		
-	// Use 'appPort' to create a container with published ports. If the port isn't working, be sure
-	// your server accepts connections from all interfaces (0.0.0.0 or '*'), not just localhost.
-	// "appPort": [],
-
-	// Uncomment the next line to run commands after the container is created.
-	// "postCreateCommand": "php -v",
-
-	// Comment out if you want to use root
 	"remoteUser": "vscode",
-
-	// Add the IDs of extensions you want installed when the container is created in the array below.
-	"extensions": [
-		"felixfbecker.php-debug",
-		"felixfbecker.php-intellisense",
-		"ikappas.composer",
-		"ikappas.phpcs"
-	]
+	"portsAttributes": {
+		"80": {
+			"label": "WordPress (via Docker localhost:8080)",
+			"onAutoForward": "ignore"
+		}
+	},
+	"postCreateCommand": "if [ -f composer.json ]; then composer install --no-interaction --prefer-dist; fi",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"bmewburn.vscode-intelephense-client",
+				"xdebug.php-debug"
+			],
+			"settings": {
+				"terminal.integrated.defaultProfile.linux": "bash",
+				"editor.formatOnSave": false,
+				"php.validate.executablePath": "/usr/local/bin/php"
+			}
+		}
+	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 			"onAutoForward": "ignore"
 		}
 	},
-	"postCreateCommand": "if [ -f composer.json ]; then composer install --no-interaction --prefer-dist; fi",
+	"postCreateCommand": "if [ -f composer.json ]; then if [ -w . ]; then composer install --no-interaction --prefer-dist; else sudo composer install --no-interaction --prefer-dist; fi; fi",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mariadb:11.4
+    image: docker.io/library/mariadb:11.4
     restart: unless-stopped
     networks:
       - devnet

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,34 +1,47 @@
-version: '3.6'
-
 services:
   db:
-    image: mariadb
-    restart: always
-    networks: 
+    image: mariadb:11.4
+    restart: unless-stopped
+    networks:
       - devnet
     environment:
-      MYSQL_DATABASE: wordydb
-      MYSQL_USER: wordyuser
-      MYSQL_PASSWORD: wordypass
-      MYSQL_RANDOM_ROOT_PASSWORD: '1'
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-wordydb}
+      MYSQL_USER: ${MYSQL_USER:-wordyuser}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-wordypass}
+      MYSQL_RANDOM_ROOT_PASSWORD: "1"
+    volumes:
+      - db_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD-SHELL", "mariadb-admin ping -h localhost -u\"$$MYSQL_USER\" -p\"$$MYSQL_PASSWORD\" || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
 
   wordpress:
     build:
       context: .
       dockerfile: Dockerfile
-    restart: always
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
     networks:
       - devnet
     ports:
-      - 8080:80
+      - "127.0.0.1:8080:80"
     volumes:
       - ..:/workspace:cached
       - ../wordpress:/var/www/html
     environment:
-      WORDPRESS_DB_HOST: db
-      WORDPRESS_DB_USER: wordyuser
-      WORDPRESS_DB_PASSWORD: wordypass
-      WORDPRESS_DB_NAME: wordydb
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_USER: ${MYSQL_USER:-wordyuser}
+      WORDPRESS_DB_PASSWORD: ${MYSQL_PASSWORD:-wordypass}
+      WORDPRESS_DB_NAME: ${MYSQL_DATABASE:-wordydb}
+      WORDPRESS_CONFIG_EXTRA: "define( 'FS_METHOD', 'direct' );"
 
-networks: 
+networks:
   devnet:
+
+volumes:
+  db_data:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,101 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 5
+    assignees:
+      - markheydon
+    labels:
+      - dependencies
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: devcontainers
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 5
+    assignees:
+      - markheydon
+    labels:
+      - dependencies
+    groups:
+      devcontainers:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 5
+    assignees:
+      - markheydon
+    labels:
+      - dependencies
+    groups:
+      composer:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: docker
+    directory: /.devcontainer
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 5
+    assignees:
+      - markheydon
+    labels:
+      - dependencies
+    groups:
+      docker:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: docker-compose
+    directory: /.devcontainer
+    schedule:
+      interval: weekly
+      day: monday
+      time: "04:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 5
+    assignees:
+      - markheydon
+    labels:
+      - dependencies
+    groups:
+      docker-compose:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/vendor/
+/wordpress/
+/node_modules/
+/.phpcs.cache
+.DS_Store

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,14 +1,29 @@
 {
-  "version": "0.2.0",
-  "configurations": [
-    {
-      "name": "Listen for XDebug",
-      "type": "php",
-      "request": "launch",
-      "port": 9000,
-      "pathMappings": {
-        "/var/www/html/": "${workspaceRoot}/wordpress"
-      }
-    }
-  ]
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Listen for Xdebug",
+			"type": "php",
+			"request": "launch",
+			"port": 9003,
+			"pathMappings": {
+				"/var/www/html/": "${workspaceFolder}/wordpress"
+			}
+		},
+		{
+			"name": "Launch currently open script",
+			"type": "php",
+			"request": "launch",
+			"program": "${file}",
+			"cwd": "${fileDirname}",
+			"port": 0,
+			"runtimeArgs": [
+				"-dxdebug.start_with_request=yes"
+			],
+			"env": {
+				"XDEBUG_MODE": "debug,develop",
+				"XDEBUG_CONFIG": "client_port=${port}"
+			}
+		}
+	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,31 @@
 {
-    "composer.executablePath": "/usr/local/bin/composer",
-    "phpcs.standard": "WordPress"
+	"files.associations": {
+		"*.php": "php"
+	},
+	"editor.tabSize": 4,
+	"editor.insertSpaces": false,
+	"editor.detectIndentation": false,
+	"editor.formatOnSave": false,
+	"files.trimTrailingWhitespace": true,
+	"files.insertFinalNewline": true,
+	"files.eol": "\n",
+	"php.validate.executablePath": "php",
+	"intelephense.files.exclude": [
+		"**/vendor/**",
+		"**/node_modules/**",
+		"**/wordpress/**"
+	],
+	"search.exclude": {
+		"**/vendor": true,
+		"**/node_modules": true,
+		"**/wordpress": true
+	},
+	"files.watcherExclude": {
+		"**/vendor/**": true,
+		"**/node_modules/**": true,
+		"**/wordpress/**": true
+	},
+	"[php]": {
+		"editor.defaultFormatter": "bmewburn.vscode-intelephense-client"
+	}
 }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repo stays intentionally smaller: a generic container you can drop into any
 
 Without modification, the supplied configuration provides:
 
-- WordPress container based on `wordpress:php8.4-apache`
+- WordPress container based on `docker.io/library/wordpress:php8.4-apache`
 - MariaDB 11.4 with a persistent database volume
 - Workspace mounted at `/workspace`
 - WordPress files mapped to `./wordpress` (`/var/www/html` in the container)
@@ -64,15 +64,17 @@ composer lint:fix
 
 ## PHP version
 
-The container is pinned to **PHP 8.4** (`wordpress:php8.4-apache`). That is a current, well-supported default, not a match for every existing plugin or theme.
+The container is pinned to **PHP 8.4** (`docker.io/library/wordpress:php8.4-apache`). That is a current, well-supported default, not a match for every existing plugin or theme.
+
+Images are fully qualified (`docker.io/library/...`) so Docker and Podman both resolve them. Short names like `wordpress:php8.4-apache` work on Docker; Podman often does not, unless you configure unqualified search registries.
 
 If you drop these files into a project that already targets another PHP release, change the image before you build. In [`.devcontainer/Dockerfile`](.devcontainer/Dockerfile):
 
 ```dockerfile
-ARG WORDPRESS_IMAGE=wordpress:php8.4-apache
+ARG WORDPRESS_IMAGE=docker.io/library/wordpress:php8.4-apache
 ```
 
-Use the matching official tag, for example `wordpress:php8.3-apache` or `wordpress:php8.5-apache`. See [WordPress Docker tags](https://hub.docker.com/_/wordpress) and [WordPress PHP compatibility](https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/).
+Use the matching official tag, for example `docker.io/library/wordpress:php8.3-apache` or `docker.io/library/wordpress:php8.5-apache`. See [WordPress Docker tags](https://hub.docker.com/_/wordpress) and [WordPress PHP compatibility](https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/).
 
 If you copied `composer.json` / `phpcs.xml` (or already have them), update the Composer `php` requirement and the PHPCS `testVersion` so they match the image you chose.
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Follow these steps in order. Later sections are extras (PHP version, plugin volu
 2. If you have not used Dev Containers before, read the [Getting Started](https://code.visualstudio.com/docs/devcontainers/containers#_getting-started) guide.
 3. Download the latest release ZIP from this repository, or copy the files from a checkout.
 4. Place `.devcontainer` and `.vscode` in the root of your VS Code workspace (where your project files live).
-5. Add PHP CodeSniffer with WordPress Coding Standards:
-   - If the project does **not** already use Composer, also copy `composer.json` and `phpcs.xml` into that same workspace root. Update the package `name` in `composer.json`.
+5. Optionally add PHP CodeSniffer with WordPress Coding Standards. Composer is not required for the container to run; skip this step if you do not want it.
+   - If the project does **not** already use Composer, copy `composer.json` and `phpcs.xml` into that same workspace root.
    - If the project **already** uses Composer, do not overwrite `composer.json`. Add these packages instead:
 
      ```
@@ -47,13 +47,15 @@ Follow these steps in order. Later sections are extras (PHP version, plugin volu
      ```
 
      Copy `phpcs.xml` if you do not already have a PHPCS config.
-6. Update the `name` in `.devcontainer/devcontainer.json` to match your project if you want.
+6. Update project names to match your workspace:
+   - `name` in `.devcontainer/devcontainer.json`
+   - `name` in `composer.json`, if you copied that file in the previous step
 7. If this project is not on PHP 8.4, change the image tag **before** the first build (see [PHP version](#php-version)).
 8. Open the Command Palette and run **Dev Containers: Reopen in Container**.
 9. Wait for the container to finish starting. If `composer.json` is present, Composer dependencies install automatically.
 10. Open `http://localhost:8080` and complete the WordPress installer.
 
-Inside the container you can check coding standards with:
+If you added Composer, you can check coding standards inside the container with:
 
 ```bash
 composer lint

--- a/README.md
+++ b/README.md
@@ -1,82 +1,103 @@
-# Repo now archived
+# WordPress Visual Studio Code Container
 
-As part of my recent review of all my repos, I've decided to archive this one and replace with these two more modern templates.
+A drop-in [VS Code Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers) setup for WordPress development.
 
-* Specific Avada child theme based template -- https://github.com/markheydon/avada-child-theme-dev
-* WordPress plugin template based on the original boilerplate -- https://github.com/markheydon/wordpress-plugin-dev
+This repository is **not** designed to be cloned and used as a project. Copy the `.devcontainer` and `.vscode` folders into your existing WordPress plugin or theme workspace, then reopen the folder in a container.
 
-<details>
+## Looking for a full project template?
 
-<summary>Original repo README...</summary>
-    
-# Wordpress Visual Studio Code Container
-A simple Visual Studio Code Docker container setup for WordPress development.  See [Developing inside a Container](https://code.visualstudio.com/docs/remote/containers) for more information on using containers in VS Code.
+If you want a GitHub template with plugin or theme scaffolding, automated setup, and distribution workflows, use one of these instead:
+
+- [wordpress-plugin-dev](https://github.com/markheydon/wordpress-plugin-dev) — WordPress plugin development template
+- [avada-child-theme-dev](https://github.com/markheydon/avada-child-theme-dev) — Avada child theme development template
+
+This repo stays intentionally smaller: a generic container you can drop into any WordPress codebase.
 
 ## What's included?
 
-The files in this project are designed to be dropped-in to a VS Code workspace as-is to provide a simple, working, container for WordPress development.  In other words, this repository is not designed to be cloned and used directly.
+Without modification, the supplied configuration provides:
 
-The configuration files have not been tested with all possible variations of WordPress development, but I personally use them for plugin development including WP CLI projects.
+- WordPress container based on `wordpress:php8.4-apache`
+- MariaDB 11.4 with a persistent database volume
+- Workspace mounted at `/workspace`
+- WordPress files mapped to `./wordpress` (`/var/www/html` in the container)
+- PHP Composer and WP-CLI installed
+- Xdebug 3 enabled (listen on port 9003)
+- `WP_DEBUG` enabled via `WORDPRESS_DEBUG`
+- Direct filesystem writes via `FS_METHOD` for local development
 
-Without modification, the supplied configuration provices the following.
+The configuration has not been tested with every possible WordPress setup, but it is intended for plugin and theme development, including WP-CLI workflows.
 
-- Main VS Code container running the official Docker Hub wordpress image.
-- Mapped folder `./wordpress` to the container WordPress folder (`/var/www/html`).
-- Additional container running MariaDB.
-- PHP Composer installed.
-- WP CLI installed.
-- XDebug enabled via port 9000.
-- WP_DEBUG enabled in wp-config.php file.
+## Getting started
 
-## Getting Started
+1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) in VS Code.
+2. If you have not used Dev Containers before, read the [Getting Started](https://code.visualstudio.com/docs/devcontainers/containers#_getting-started) guide.
+3. Download the latest release ZIP from this repository, or copy `.devcontainer` and `.vscode` from a checkout.
+4. Place those folders in the root of your VS Code workspace (where your project files live).
+5. Update the `name` in `.devcontainer/devcontainer.json` to match your project if you want.
+6. Open the Command Palette and run **Dev Containers: Reopen in Container**.
 
-These instructions should get you a working container environment to test and debug your WordPress project.
+On first run, open `http://localhost:8080` and complete the WordPress installer.
 
-1. Install the [Visual Studio Code Remote Development Extension Pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) if you don't have it installed already in VS Code.
-1. Additionally, if you haven't already, follow the [Getting Started](https://code.visualstudio.com/docs/remote/containers#_getting-started) steps in the VS Code documenation.
-1. Download the latest zip release file from this repository and unzip to a temporary folder.
-1. Copy the folders `.vscode` and `.devcontainer` from the download into the root of your VS Code workspace folder, i.e. the top level where your project code files are in VS Code.  Amend as needed for your project.
-1. Although the files can be used as-is, you may want to at least update the 'name' in the `.devcontainer/devcontainer.json` file to match that of your project.
-1. At this point, you can open the VS Code command pallette and use the **Remote-Containers: Reopen Folder in Container** command to fire up the container.
+## Making changes
 
-Once the container is built and up and running, you should be able to access the WordPress instance via `http://localhost:8080`.  The installer should appear on first run.
+If you edit `.devcontainer/Dockerfile` or `.devcontainer/docker-compose.yml`, rebuild with **Dev Containers: Rebuild Container**.
 
-## Making Changes
+## Optional Composer and PHPCS
 
-If you want to amend the supplied Dockerfile or docker-compose.yml to your own liking, do so but don't forget to use the **Remote-Containers: Rebuild Container** command in VS Code command to rebuild the VS Code container.
+An optional `composer.json` is included to install PHP CodeSniffer with WordPress Coding Standards.
 
-## Optional 'composer.json' File
+If you are not already using Composer in your project, copy in the supplied `composer.json` and `phpcs.xml`, update the package `name`, then run:
 
-If you aren't using Composer in your project already, feel free to copy in the `composer.json` file supplied.  This enables the PHP Code Sniffer with the WordPress standard installed.  Update the file as required for your project, again at least the 'name' should be changed and remove the 'type' or update it to 'project'.  Run the `Composer: Update` command from the command pallette to install/enable.
-
-If you are using Composer already, then 'require' the following to enable PHP Code Sniffer if you haven't installed/enabled it already.
-
-```
-squizlabs/php_codesniffer:^3.5
-dealerdirect/phpcodesniffer-composer-installer:*
-wp-coding-standards/wpcs:*
+```bash
+composer install
 ```
 
+Composer dependencies are also installed automatically when the dev container starts, if `composer.json` is present.
 
-## Use for Developing Plugins
+Useful commands:
 
-The easiest way to include these files in a Plugin respository, is to follow the [WordPress Plugin Handbook - Best Practices Folder Structure](https://developer.wordpress.org/plugins/plugin-basics/best-practices/#folder-structure) and have a folder at root level named the same as your plugin.  Then, in the docker-compose.yml add something such as the following under the `- ../wordpress:/var/www/html` line under `volumes`...
+```bash
+composer lint
+composer lint:fix
+```
+
+If you already have Composer, add these packages instead:
 
 ```
+squizlabs/php_codesniffer:^3.13
+dealerdirect/phpcodesniffer-composer-installer:^1.1
+wp-coding-standards/wpcs:^3.3
+```
+
+## Use for developing plugins
+
+The easiest approach is to follow the [WordPress Plugin Handbook folder structure](https://developer.wordpress.org/plugins/plugin-basics/best-practices/#folder-structure) and keep your plugin at the workspace root. Then add a volume mapping in `.devcontainer/docker-compose.yml` under the `wordpress` service:
+
+```yaml
     volumes:
       - ..:/workspace:cached
       - ../wordpress:/var/www/html
       - ../plugin-name:/var/www/html/wp-content/plugins/plugin-name
 ```
 
-This will map the root level `plugin-name` folder to the right place in the container.  Update the `.vscode/launch.json` file `pathMappings` section to enable debugging of the same.
+Update `.vscode/launch.json` `pathMappings` if you want to debug plugin files separately:
+
+```json
+"pathMappings": {
+    "/var/www/html/": "${workspaceFolder}/wordpress",
+    "/var/www/html/wp-content/plugins/plugin-name/": "${workspaceFolder}/plugin-name"
+}
+```
+
+## Debugging
+
+Xdebug 3 is configured to listen on port **9003**. Use the **Listen for Xdebug** launch configuration in VS Code.
 
 ## Contributing
 
-Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
+Please read [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md) for contribution guidance.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-</details>
+This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A drop-in [VS Code Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers) setup for WordPress development.
 
-This repository is **not** designed to be cloned and used as a project. Copy the `.devcontainer` and `.vscode` folders into your existing WordPress plugin or theme workspace, then reopen the folder in a container.
+This repository is **not** designed to be cloned and used as a project. Copy the files into your existing WordPress plugin or theme workspace, then reopen the folder in a container. See [Getting started](#getting-started) for the full set of files.
 
 ## Looking for a full project template?
 
@@ -30,14 +30,35 @@ The configuration has not been tested with every possible WordPress setup, but i
 
 ## Getting started
 
+Follow these steps in order. Later sections are extras (PHP version, plugin volume mapping, debugging), not a second copy of the setup.
+
 1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) in VS Code.
 2. If you have not used Dev Containers before, read the [Getting Started](https://code.visualstudio.com/docs/devcontainers/containers#_getting-started) guide.
-3. Download the latest release ZIP from this repository, or copy `.devcontainer` and `.vscode` from a checkout.
-4. Place those folders in the root of your VS Code workspace (where your project files live).
-5. Update the `name` in `.devcontainer/devcontainer.json` to match your project if you want.
-6. Open the Command Palette and run **Dev Containers: Reopen in Container**.
+3. Download the latest release ZIP from this repository, or copy the files from a checkout.
+4. Place `.devcontainer` and `.vscode` in the root of your VS Code workspace (where your project files live).
+5. Add PHP CodeSniffer with WordPress Coding Standards:
+   - If the project does **not** already use Composer, also copy `composer.json` and `phpcs.xml` into that same workspace root. Update the package `name` in `composer.json`.
+   - If the project **already** uses Composer, do not overwrite `composer.json`. Add these packages instead:
 
-On first run, open `http://localhost:8080` and complete the WordPress installer.
+     ```
+     squizlabs/php_codesniffer:^3.13
+     dealerdirect/phpcodesniffer-composer-installer:^1.1
+     wp-coding-standards/wpcs:^3.3
+     ```
+
+     Copy `phpcs.xml` if you do not already have a PHPCS config.
+6. Update the `name` in `.devcontainer/devcontainer.json` to match your project if you want.
+7. If this project is not on PHP 8.4, change the image tag **before** the first build (see [PHP version](#php-version)).
+8. Open the Command Palette and run **Dev Containers: Reopen in Container**.
+9. Wait for the container to finish starting. If `composer.json` is present, Composer dependencies install automatically.
+10. Open `http://localhost:8080` and complete the WordPress installer.
+
+Inside the container you can check coding standards with:
+
+```bash
+composer lint
+composer lint:fix
+```
 
 ## PHP version
 
@@ -51,40 +72,13 @@ ARG WORDPRESS_IMAGE=wordpress:php8.4-apache
 
 Use the matching official tag, for example `wordpress:php8.3-apache` or `wordpress:php8.5-apache`. See [WordPress Docker tags](https://hub.docker.com/_/wordpress) and [WordPress PHP compatibility](https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/).
 
-If you also copy the optional `composer.json` / `phpcs.xml`, update the Composer `php` requirement and the PHPCS `testVersion` so they match the image you chose.
+If you copied `composer.json` / `phpcs.xml` (or already have them), update the Composer `php` requirement and the PHPCS `testVersion` so they match the image you chose.
 
 Then rebuild with **Dev Containers: Rebuild Container**. Confirm with `php -v` inside the container.
 
 ## Making changes
 
 If you edit `.devcontainer/Dockerfile` or `.devcontainer/docker-compose.yml`, rebuild with **Dev Containers: Rebuild Container**.
-
-## Optional Composer and PHPCS
-
-An optional `composer.json` is included to install PHP CodeSniffer with WordPress Coding Standards.
-
-If you are not already using Composer in your project, copy in the supplied `composer.json` and `phpcs.xml`, update the package `name`, then run:
-
-```bash
-composer install
-```
-
-Composer dependencies are also installed automatically when the dev container starts, if `composer.json` is present.
-
-Useful commands:
-
-```bash
-composer lint
-composer lint:fix
-```
-
-If you already have Composer, add these packages instead:
-
-```
-squizlabs/php_codesniffer:^3.13
-dealerdirect/phpcodesniffer-composer-installer:^1.1
-wp-coding-standards/wpcs:^3.3
-```
 
 ## Use for developing plugins
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ Then rebuild with **Dev Containers: Rebuild Container**. Confirm with `php -v` i
 
 If you edit `.devcontainer/Dockerfile` or `.devcontainer/docker-compose.yml`, rebuild with **Dev Containers: Rebuild Container**.
 
+## Podman
+
+These files work with Podman as well as Docker. Point VS Code **Docker Path** at `podman`, install a compose provider in the same WSL distro (`docker-compose-v2` or `podman-compose`), and use fully qualified image names as shipped here.
+
+Rootless Podman maps bind-mount UIDs differently from Docker. If `composer install` cannot write `composer.lock` or `vendor/`, the post-create step falls back to `sudo`. To make the `vscode` user match your host user (so you can write without sudo), add this to the `wordpress` service in `docker-compose.yml` — **Podman only**; Docker does not accept it:
+
+```yaml
+    userns_mode: keep-id
+```
+
 ## Use for developing plugins
 
 The easiest approach is to follow the [WordPress Plugin Handbook folder structure](https://developer.wordpress.org/plugins/plugin-basics/best-practices/#folder-structure) and keep your plugin at the workspace root. Then add a volume mapping in `.devcontainer/docker-compose.yml` under the `wordpress` service:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,22 @@ The configuration has not been tested with every possible WordPress setup, but i
 
 On first run, open `http://localhost:8080` and complete the WordPress installer.
 
+## PHP version
+
+The container is pinned to **PHP 8.4** (`wordpress:php8.4-apache`). That is a current, well-supported default, not a match for every existing plugin or theme.
+
+If you drop these files into a project that already targets another PHP release, change the image before you build. In [`.devcontainer/Dockerfile`](.devcontainer/Dockerfile):
+
+```dockerfile
+ARG WORDPRESS_IMAGE=wordpress:php8.4-apache
+```
+
+Use the matching official tag, for example `wordpress:php8.3-apache` or `wordpress:php8.5-apache`. See [WordPress Docker tags](https://hub.docker.com/_/wordpress) and [WordPress PHP compatibility](https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/).
+
+If you also copy the optional `composer.json` / `phpcs.xml`, update the Composer `php` requirement and the PHPCS `testVersion` so they match the image you chose.
+
+Then rebuild with **Dev Containers: Rebuild Container**. Confirm with `php -v` inside the container.
+
 ## Making changes
 
 If you edit `.devcontainer/Dockerfile` or `.devcontainer/docker-compose.yml`, rebuild with **Dev Containers: Rebuild Container**.

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,26 @@
 {
-    "name": "mhcg/wordpress-vscode-container",
-    "description": "Composer configuration to enable PHP Code Sniffer with the WordPress standard installed.",
-    "license": "GPL-2.0-or-later",
-    "type": "metapackages",
-    "require": {
-        "php": ">=7.2"
-    },
-    "require-dev": {
-        "squizlabs/php_codesniffer": "^3.5",
-        "dealerdirect/phpcodesniffer-composer-installer": "*",
-        "wp-coding-standards/wpcs": "*"
-    }
+	"name": "mhcg/wordpress-vscode-container",
+	"description": "Optional Composer configuration for PHP CodeSniffer with WordPress Coding Standards.",
+	"type": "project",
+	"license": "GPL-2.0-or-later",
+	"require": {
+		"php": ">=8.3"
+	},
+	"require-dev": {
+		"dealerdirect/phpcodesniffer-composer-installer": "^1.1",
+		"squizlabs/php_codesniffer": "^3.13.4",
+		"wp-coding-standards/wpcs": "^3.3"
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		},
+		"sort-packages": true
+	},
+	"scripts": {
+		"lint": "phpcs --standard=phpcs.xml",
+		"lint:fix": "phpcbf --standard=phpcs.xml",
+		"lint:php": "phpcs --standard=phpcs.xml --extensions=php --report=full",
+		"standards": "phpcs -i"
+	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress VS Code Container">
+	<description>Project coding standards for WordPress development.</description>
+
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/wordpress/*</exclude-pattern>
+	<exclude-pattern>*/.devcontainer/*</exclude-pattern>
+	<exclude-pattern>*/.vscode/*</exclude-pattern>
+
+	<arg name="basepath" value="."/>
+	<arg name="colors"/>
+	<arg name="parallel" value="4"/>
+	<arg value="sp"/>
+	<arg name="cache" value=".phpcs.cache"/>
+
+	<config name="testVersion" value="8.2-8.4"/>
+
+	<rule ref="WordPress-Core"/>
+	<rule ref="WordPress-Extra"/>
+	<rule ref="WordPress-Docs"/>
+
+	<exclude name="WordPress.Files.FileName"/>
+</ruleset>


### PR DESCRIPTION
## Summary

- Un-archives the repo with a rewritten README that keeps this as a generic drop-in starter and points to `wordpress-plugin-dev` / `avada-child-theme-dev` for full project templates.
- Modernizes the dev container stack: PHP 8.4 image pin, MariaDB 11.4 with healthcheck and persistent volume, Xdebug 3 on port 9003, and current VS Code Dev Containers settings/extensions.
- Refreshes optional Composer/PHPCS tooling (`composer.json`, `phpcs.xml`, `.gitignore`) without adding template scaffolding or auto WordPress install.

## Test plan

- [ ] Copy `.devcontainer` and `.vscode` into a test WordPress workspace
- [ ] Reopen in Dev Container and confirm build succeeds
- [ ] Visit `http://localhost:8080` and complete WordPress installer
- [ ] Start **Listen for Xdebug** and confirm breakpoints hit on port 9003
- [ ] Run `composer install` and `composer lint` if using the optional PHPCS setup


Made with [Cursor](https://cursor.com)